### PR TITLE
Fix Terraform download checksum verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,13 @@ RUN set -eux; \
     esac; \
     terraform_file="terraform_${TERRAFORM_VERSION}_linux_${terraform_arch}.zip"; \
     terraform_url="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${terraform_file}"; \
-    curl -fsSLo /tmp/terraform.zip "$terraform_url"; \
+    terraform_zip="/tmp/${terraform_file}"; \
+    curl -fsSLo "$terraform_zip" "$terraform_url"; \
     curl -fsSLo /tmp/terraform_SHA256SUMS "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS"; \
     grep "  ${terraform_file}" /tmp/terraform_SHA256SUMS > /tmp/terraform_SHA256SUMS_filtered; \
-    sha256sum -c /tmp/terraform_SHA256SUMS_filtered; \
-    unzip /tmp/terraform.zip -d /usr/local/bin; \
-    rm /tmp/terraform.zip /tmp/terraform_SHA256SUMS /tmp/terraform_SHA256SUMS_filtered; \
+    (cd /tmp && sha256sum -c terraform_SHA256SUMS_filtered); \
+    unzip "$terraform_zip" -d /usr/local/bin; \
+    rm "$terraform_zip" /tmp/terraform_SHA256SUMS /tmp/terraform_SHA256SUMS_filtered; \
     terraform --version
 
 # Switch back to the jenkins user


### PR DESCRIPTION
## Summary
- save the Terraform archive using its canonical release filename
- verify the SHA256 checksum from the release directory before installing

## Testing
- docker build . *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d065099c24832c978344d548b88549