### PR TITLE
Align controller image tooling with agents

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -28,15 +28,15 @@ jobs:
       - name: Extract Jenkins version from Dockerfile
         id: get_version
         run: |
-          version=$(grep -oP 'FROM [^:]+:\K[\d\.]+' Dockerfile)
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Log the extracted version
-        run: echo "Jenkins version is ${{ steps.get_version.outputs.version }}"
+          version=$(grep -oP 'FROM\s+[^\s:]+:\K[^\s]+' Dockerfile)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-platform Docker image (version + latest)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,40 +3,126 @@ FROM jenkins/jenkins:2.528
 # Switch to root for installing plugins and additional tools
 USER root
 
+# TARGETARCH is automatically populated by BuildKit when building multi-platform
+# images. Fallback to the runtime architecture when building without BuildKit or
+# on a single architecture.
+ARG TARGETARCH
+
 # Copy the plugins file and install plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt --verbose
 
-# Install dependencies required for Ansible and Terraform
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install common dependencies and tools aligned with the inbound agent image
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    common_packages="apt-transport-https \
+      curl \
+      gnupg \
+      lsb-release \
+      software-properties-common \
+      jq \
+      python3 \
+      python3-pip \
+      bat \
+      bridge-utils \
+      btop \
+      dnsutils \
+      duf \
+      ethtool \
+      fd-find \
+      gh \
+      git \
+      htop \
+      ifupdown \
+      iotop \
+      iperf3 \
+      iptables \
+      libvirt-clients \
+      libvirt-daemon-system \
+      lshw \
+      lsof \
+      make \
+      default-mysql-client \
+      nano \
+      net-tools \
+      netcat-openbsd \
+      neovim \
+      nfs-common \
+      nmap \
+      open-iscsi \
+      parted \
+      postgresql-client \
+      python3-venv \
+      qemu-guest-agent \
+      ripgrep \
+      rsync \
+      screen \
+      smartmontools \
+      strace \
+      tcpdump \
+      tmux \
+      traceroute \
+      tree \
+      ufw \
+      unzip \
+      util-linux \
+      vim \
+      virtinst \
+      wget \
+      whois \
+      xorriso \
+      zip"; \
+    arch_packages=""; \
+    case "$arch" in \
+      amd64|x86_64) \
+        arch_packages="cpu-checker qemu-kvm qemu-system-x86" \
+        ;; \
+      arm64|aarch64) \
+        arch_packages="qemu-system-arm" \
+        ;; \
+      *) \
+        echo "Unsupported architecture: $arch" >&2; exit 1 \
+        ;; \
+    esac; \
+    apt-get install -y --no-install-recommends $common_packages $arch_packages; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install boto3 and botocore via pip, overriding system restrictions.
+RUN pip3 install --break-system-packages boto3 botocore
+
+# Add the HashiCorp repository (Terraform + Packer come from here)
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64|x86_64) repo_arch="amd64" ;; \
+      arm64|aarch64) repo_arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /usr/share/keyrings; \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg; \
+    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"; \
+    echo "deb [arch=${repo_arch} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com ${codename} main" > /etc/apt/sources.list.d/hashicorp.list
+
+# Install Terraform, Packer, and Ansible from the HashiCorp repository
+RUN apt-get update && apt-get install -y \
+    terraform \
+    packer \
     ansible \
-    curl \
-    unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Terraform from HashiCorp release archives for the active architecture
-ARG TERRAFORM_VERSION=1.7.5
-# TARGETARCH is automatically populated by BuildKit when building multi-platform
-# images. Fallback to dpkg when building without BuildKit or on a single
-# architecture.
-ARG TARGETARCH
+# Install MinIO Client
 RUN set -eux; \
-    detected_arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
-    case "$detected_arch" in \
-      amd64|x86_64) terraform_arch="amd64" ;; \
-      arm64|aarch64) terraform_arch="arm64" ;; \
-      *) echo "Unsupported architecture: $detected_arch" >&2; exit 1 ;; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64|x86_64) mc_arch="amd64" ;; \
+      arm64|aarch64) mc_arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    terraform_file="terraform_${TERRAFORM_VERSION}_linux_${terraform_arch}.zip"; \
-    terraform_url="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${terraform_file}"; \
-    terraform_zip="/tmp/${terraform_file}"; \
-    curl -fsSLo "$terraform_zip" "$terraform_url"; \
-    curl -fsSLo /tmp/terraform_SHA256SUMS "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS"; \
-    grep "  ${terraform_file}" /tmp/terraform_SHA256SUMS > /tmp/terraform_SHA256SUMS_filtered; \
-    (cd /tmp && sha256sum -c terraform_SHA256SUMS_filtered); \
-    unzip "$terraform_zip" -d /usr/local/bin; \
-    rm "$terraform_zip" /tmp/terraform_SHA256SUMS /tmp/terraform_SHA256SUMS_filtered; \
-    terraform --version
+    curl -sSL "https://dl.min.io/client/mc/release/linux-${mc_arch}/mc" -o /usr/local/bin/mc; \
+    chmod +x /usr/local/bin/mc
 
 # Switch back to the jenkins user
 USER jenkins


### PR DESCRIPTION
## Summary
- install the same system packages on the controller image that are available in the inbound agent image, including boto3/botocore and the MinIO client
- add the HashiCorp APT repository so Terraform and Packer are installed from packages instead of manual archives
- modernize the build workflow to use the docker/login action and more robust version extraction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d079ce05e8832cbf4b19c7261c442d