### PR TITLE
Add armv7 build support for controller image

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push multi-platform Docker image (version + latest)
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --tag ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }} \
             --tag ghcr.io/${{ github.repository }}:latest \
             --push \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,16 @@ FROM jenkins/jenkins:2.528
 # Switch to root for installing plugins and additional tools
 USER root
 
-# TARGETARCH is automatically populated by BuildKit when building multi-platform
-# images. Fallback to the runtime architecture when building without BuildKit or
-# on a single architecture.
+# TARGETARCH and TARGETVARIANT are automatically populated by BuildKit when
+# building multi-platform images. Fallback to the runtime architecture and
+# variant when building without BuildKit or on a single architecture.
 ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Default versions for HashiCorp tools installed when repository packages are
+# unavailable for the target architecture.
+ARG PACKER_VERSION=1.11.1
+ARG TERRAFORM_VERSION=1.9.5
 
 # Copy the plugins file and install plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
@@ -14,7 +20,12 @@ RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt --verbos
 
 # Install common dependencies and tools aligned with the inbound agent image
 RUN set -eux; \
-    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    raw_arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    variant="${TARGETVARIANT:-}"; \
+    if { [ "$raw_arch" = "arm" ] || [ "$raw_arch" = "armhf" ] || [ "$raw_arch" = "armv7l" ]; } \
+       && [ -n "$variant" ] && [ "$variant" != "v7" ]; then \
+      echo "Unsupported ARM variant: $variant" >&2; exit 1; \
+    fi; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
     common_packages="apt-transport-https \
@@ -75,15 +86,18 @@ RUN set -eux; \
       xorriso \
       zip"; \
     arch_packages=""; \
-    case "$arch" in \
+    case "$raw_arch" in \
       amd64|x86_64) \
         arch_packages="cpu-checker qemu-kvm qemu-system-x86" \
         ;; \
       arm64|aarch64) \
         arch_packages="qemu-system-arm" \
         ;; \
+      arm|armhf|armv7l) \
+        arch_packages="qemu-system-arm" \
+        ;; \
       *) \
-        echo "Unsupported architecture: $arch" >&2; exit 1 \
+        echo "Unsupported architecture: $raw_arch" >&2; exit 1 \
         ;; \
     esac; \
     apt-get install -y --no-install-recommends $common_packages $arch_packages; \
@@ -99,19 +113,55 @@ RUN set -eux; \
     case "$arch" in \
       amd64|x86_64) repo_arch="amd64" ;; \
       arm64|aarch64) repo_arch="arm64" ;; \
+      arm|armhf|armv7l) repo_arch="" ;; \
       *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
-    mkdir -p /usr/share/keyrings; \
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg; \
-    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"; \
-    echo "deb [arch=${repo_arch} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com ${codename} main" > /etc/apt/sources.list.d/hashicorp.list
+    if [ -z "$repo_arch" ]; then \
+      echo "Skipping HashiCorp repository setup for architecture $arch"; \
+    else \
+      mkdir -p /usr/share/keyrings; \
+      curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg; \
+      codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"; \
+      echo "deb [arch=${repo_arch} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com ${codename} main" > /etc/apt/sources.list.d/hashicorp.list; \
+    fi
 
-# Install Terraform, Packer, and Ansible from the HashiCorp repository
-RUN apt-get update && apt-get install -y \
-    terraform \
-    packer \
-    ansible \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install Terraform, Packer, and Ansible. For architectures where HashiCorp does
+# not publish apt packages (e.g., armhf), download verified archives instead.
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$arch" in \
+      amd64|x86_64) normalized_arch="amd64" ;; \
+      arm64|aarch64) normalized_arch="arm64" ;; \
+      arm|armhf|armv7l) normalized_arch="arm" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    if [ "$normalized_arch" = "arm" ]; then \
+      apt-get update; \
+      apt-get install -y ansible; \
+      apt-get clean; \
+      rm -rf /var/lib/apt/lists/*; \
+      for tool in terraform packer; do \
+        case "$tool" in \
+          terraform) version="$TERRAFORM_VERSION" ;; \
+          packer) version="$PACKER_VERSION" ;; \
+        esac; \
+        tmp_dir="$(mktemp -d)"; \
+        file="${tool}_${version}_linux_${normalized_arch}.zip"; \
+        url="https://releases.hashicorp.com/${tool}/${version}/${file}"; \
+        sums_url="https://releases.hashicorp.com/${tool}/${version}/${tool}_${version}_SHA256SUMS"; \
+        curl -fsSLo "${tmp_dir}/${file}" "$url"; \
+        curl -fsSLo "${tmp_dir}/SHA256SUMS" "$sums_url"; \
+        grep "  ${file}" "${tmp_dir}/SHA256SUMS" > "${tmp_dir}/SHA256SUMS.filtered"; \
+        (cd "$tmp_dir" && sha256sum -c "SHA256SUMS.filtered"); \
+        unzip -o "${tmp_dir}/${file}" -d /usr/local/bin; \
+        rm -rf "$tmp_dir"; \
+      done; \
+    else \
+      apt-get update; \
+      apt-get install -y terraform packer ansible; \
+      apt-get clean; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Install MinIO Client
 RUN set -eux; \
@@ -119,6 +169,7 @@ RUN set -eux; \
     case "$arch" in \
       amd64|x86_64) mc_arch="amd64" ;; \
       arm64|aarch64) mc_arch="arm64" ;; \
+      arm|armhf|armv7l) mc_arch="arm" ;; \
       *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
     curl -sSL "https://dl.min.io/client/mc/release/linux-${mc_arch}/mc" -o /usr/local/bin/mc; \


### PR DESCRIPTION
## Summary
- extend controller Dockerfile with ARM-specific fallbacks so terraform and packer install cleanly on 32-bit hardware
- make MinIO client and dependency installation aware of additional ARM variants
- update the GitHub Actions workflow to publish a linux/arm/v7 image alongside existing architectures

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d07eb875e0832cbb7b8c742379726f