### PR TITLE
Remove arm v7 target from build workflow

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push multi-platform Docker image (version + latest)
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --platform linux/amd64,linux/arm64 \
             --tag ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }} \
             --tag ghcr.io/${{ github.repository }}:latest \
             --push \


### PR DESCRIPTION
## Summary
- remove the linux/arm/v7 platform from the build matrix so only amd64 and arm64 images are built

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d081dd92b4832c9664cdcd10e0399f